### PR TITLE
Add info about insured person mate at lead life

### DIFF
--- a/content.js
+++ b/content.js
@@ -134,6 +134,12 @@ chrome.storage.sync.get(null, function(items) {
     trigger('insured_person_date_of_birth');
     setJobRole('life_quote[insured_person][job_role_name]', getValue('insuredPersonJobRole'));
     select('life_quote[insured_person][salary_range]', getValue('insuredPersonSalaryRange'));
+    select('life_quote[insured_person][has_mate]', getValue('insuredPersonHasMate'));
+    if (getValue('insuredPersonHasMate') === 'yes') {
+      fill_in('life_quote[insured_person_mate][date_of_birth]', getValue('insuredPersonMateDateOfBirth'));
+      trigger('insured_person_mate_date_of_birth');
+      setJobRole('life_quote[insured_person_mate][job_role_name]', getValue('insuredPersonMateJobRole'));
+    }
   }
 
   if (path === '/life/proposals/insured_people/edit') {

--- a/options.html
+++ b/options.html
@@ -121,6 +121,22 @@
       </dl>
       <hr />
 
+      <h2>Cônjuge</h2>
+      <dl>
+        <dt>Possue:</dt>
+        <dd>
+          <select id='insuredPersonHasMate'>
+            <option value="yes">Sou casado(a)</option>
+            <option value="no">Não sou casado(a)</option>
+          </select>
+        </dd>
+        <dt>Data de nascimento:</dt>
+        <dd><input id='insuredPersonMateDateOfBirth' /></dd>
+        <dt>Profissão:</dt>
+        <dd><input id='insuredPersonMateJobRole' /></dd>
+      </dl>
+      <hr />
+      
       <h2>Beneficiário</h2>
       <dl>
         <dt>Nome:</dt>

--- a/options.html
+++ b/options.html
@@ -136,7 +136,7 @@
         <dd><input id='insuredPersonMateJobRole' /></dd>
       </dl>
       <hr />
-      
+
       <h2>Beneficiário</h2>
       <dl>
         <dt>Nome:</dt>
@@ -144,6 +144,7 @@
         <dt>Parentesco:</dt>
         <dd>
           <select id='beneficiaryRelationship'>
+            <option value="mother">Mãe</option>
             <option value="father">Pai</option>
             <option value="daughter">Filha</option>
             <option value="son">Filho</option>

--- a/options.html
+++ b/options.html
@@ -123,11 +123,11 @@
 
       <h2>Cônjuge</h2>
       <dl>
-        <dt>Possue:</dt>
+        <dt>É casado:</dt>
         <dd>
           <select id='insuredPersonHasMate'>
-            <option value="yes">Sou casado(a)</option>
-            <option value="no">Não sou casado(a)</option>
+            <option value="yes">Sim</option>
+            <option value="no">Não</option>
           </select>
         </dd>
         <dt>Data de nascimento:</dt>

--- a/options.js
+++ b/options.js
@@ -37,6 +37,10 @@ var attributes = {
   propertyCep: '08461-660',
 
   // LIFE
+  insuredPersonHasMate: 'yes',
+  insuredPersonMateDateOfBirth: '31/12/1980',
+  insuredPersonMateJobRole: 'Professor',
+
   beneficiaryName: 'Jane Roe',
   beneficiaryRelationship: 'father',
   beneficiaryCompensation: '100,00%'


### PR DESCRIPTION
The objective  this PR is the automatic filling of fields of insured person mate from lead only life. And add relationship option "Mother" at beneficiaries.

Automatic filling of fields:
![](http://g.recordit.co/gUg1GPR10O.gif)

Add mom:
![screen shot 2016-05-31 at 8 08 46 pm](https://cloud.githubusercontent.com/assets/3799482/15694514/f19454ec-2774-11e6-935a-f3e947a8d9db.png)

